### PR TITLE
host euw changed

### DIFF
--- a/lib/observer.js
+++ b/lib/observer.js
@@ -5,7 +5,7 @@ module.exports = Observer
 
 var hostList = {
     "na":   "spectator.na.lol.riotgames.com:8088",
-    "euw":  "spectator.eu.lol.riotgames.com:8088",
+    "euw":  "spectator.euw1.lol.riotgames.com:80",
     "eune": "spectator.eu.lol.riotgames.com:8088",
     "br":   "spectator.br.lol.riotgames.com:80",
     "lan":  "spectator.br.lol.riotgames.com:80",


### PR DESCRIPTION
hi guy the host of the EUW have changed now EUW is splited of the EUNE

EUW = http://spectator.euw1.lol.riotgames.com/observer-mode/rest/featured
EUNE = http://spectator.eu.lol.riotgames.com:8088/observer-mode/rest/featured
